### PR TITLE
shared-vpc: created new setters for current network, subnetwork, and …

### DIFF
--- a/distributions/gcp/Kptfile
+++ b/distributions/gcp/Kptfile
@@ -850,3 +850,36 @@ openAPI:
           values:
           - marker: ${mgmt-project}
             ref: '#/definitions/io.k8s.cli.setters.mgmt-project'
+    io.k8s.cli.setters.network-ref-name:
+      x-k8s-cli:
+        setter:
+          name: network-ref-name
+          value: name
+    io.k8s.cli.setters.network-ref-external:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: network-ref-external
+          value: ""
+    io.k8s.cli.setters.router-ref-name:
+      x-k8s-cli:
+        setter:
+          name: router-ref-name
+          value: name
+    io.k8s.cli.setters.router-ref-external:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: router-ref-external
+          value: ""
+    io.k8s.cli.setters.subnetwork-ref-name:
+      x-k8s-cli:
+        setter:
+          name: subnetwork-ref-name
+          value: name
+    io.k8s.cli.setters.subnetwork-ref-external:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: subnetwork-ref-external
+          value: ""

--- a/distributions/gcp/v2/privateGKE/README.md
+++ b/distributions/gcp/v2/privateGKE/README.md
@@ -2,3 +2,18 @@
 
 * This directory contains CNRM patches and resource definitions in order
   to deploy Kubeflow on private GKE.
+
+# VPC Network
+
+## distributions/gcp/ kpt setters to use if VPC is in the same project as the cluster
+* network-ref-name 
+* router-ref-name
+* subnetwork-ref-name
+
+## distributions/gcp/ kpt setters to use if the VPC is in a different project
+* network-ref-external
+* router-ref-external
+* subnetwork-ref-external
+
+## VPC Notes
+Network, router, and subnetwork should all be in the same project, so don't mix and match.

--- a/distributions/gcp/v2/privateGKE/cluster-private-patch.yaml
+++ b/distributions/gcp/v2/privateGKE/cluster-private-patch.yaml
@@ -33,6 +33,8 @@ spec:
     #createSubnetwork: true
   # Create the clsuter in the private network we created.
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   subnetworkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"subnetwork-ref-external"}
+    name: name # {"$kpt-set":"subnetwork-ref-name"}

--- a/distributions/gcp/v2/privateGKE/firewall.yaml
+++ b/distributions/gcp/v2/privateGKE/firewall.yaml
@@ -13,7 +13,8 @@ spec:
   direction: EGRESS
   priority: 1100
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -35,7 +36,8 @@ spec:
   - 35.191.0.0/16
   direction: INGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -57,7 +59,8 @@ spec:
   - 35.191.0.0/16
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -75,7 +78,8 @@ spec:
   - 199.36.153.4/30
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -99,7 +103,8 @@ spec:
 
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -119,7 +124,8 @@ spec:
   - 192.168.0.0/16
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -142,7 +148,8 @@ spec:
   - 172.16.0.32/28
   direction: INGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -163,7 +170,8 @@ spec:
   - 172.16.0.32/28
   direction: INGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -219,7 +227,8 @@ spec:
   - "13.35.101.104"
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}
 ---
@@ -250,6 +259,7 @@ spec:
   - "23.202.231.169"
   direction: EGRESS
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
   # Enable logging to help debugging
   enableLogging: false # {"$kpt-set":"log-firewalls"}

--- a/distributions/gcp/v2/privateGKE/nat.yaml
+++ b/distributions/gcp/v2/privateGKE/nat.yaml
@@ -6,7 +6,8 @@ spec:
   description: Router to allow outbound internet access
   region: REGION # {"$kpt-set":"gcloud.compute.region"}
   networkRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"kpt-set":"network-ref-external"}
+    name: name # {"$kpt-set":"network-ref-name"}
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeRouterNAT
@@ -15,6 +16,7 @@ metadata:
 spec:
   region: REGION # {"$kpt-set":"gcloud.compute.region"}
   routerRef:
-    name: name # {"$kpt-set":"name"}
+    external: "" # {"$kpt-set":"router-ref-external"}
+    name: name # {"$kpt-set":"router-ref-name"}
   natIpAllocateOption: AUTO_ONLY
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES


### PR DESCRIPTION
…router that can be different than the cluster name. created new setters for shared/external network, subnetwork, and router used in cluster-private-patch, firewall and nat to set the shared/external network configuration.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt:
  **Please make sure you have installed kustomize <= 3.2.1**
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
